### PR TITLE
remove duplicate time

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -96,7 +96,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
             if (pindex->IsInMainChain())
             {
                 entry.push_back(Pair("confirmations", 1 + nBestHeight - pindex->nHeight));
-                entry.push_back(Pair("time", (int64_t)pindex->nTime));
                 entry.push_back(Pair("blocktime", (int64_t)pindex->nTime));
             }
             else


### PR DESCRIPTION
"time" (pindex->nTime) and "blocktime" (pindex->nTime) are the same value, removing second "time" entry to avoid json syntax errors
(required for newer versions of bitcoin-api) This fixes issue with Iquidus Explorer v1.7.4 no finding any TXes